### PR TITLE
Add landing page and community sections

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,0 +1,12 @@
+export default function ArticlesPage() {
+  return (
+    <main className="max-w-2xl mx-auto p-8 space-y-4">
+      <h1 className="text-3xl font-bold">Community Articles</h1>
+      <p>
+        Here you will soon find articles and blog posts written by members of
+        Homborsund AI. Stay tuned as we publish insights and tutorials from our
+        community.
+      </p>
+    </main>
+  );
+}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,18 @@
+export default function CommunityPage() {
+  return (
+    <main className="max-w-2xl mx-auto p-8 space-y-4">
+      <h1 className="text-3xl font-bold">About Homborsund AI</h1>
+      <p>
+        Homborsund AI is a community of people curious about artificial
+        intelligence and its impact on society. We meet to share ideas, discuss
+        the future of AI and arrange summits in the beautiful surroundings of
+        Homborsund.
+      </p>
+      <p>
+        Everyone is welcome, whether you are new to the field or have years of
+        experience. Our goal is to create a friendly environment where we can
+        learn from each other and collaborate on projects.
+      </p>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,9 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Homborsund AI Conference",
-  description: "No tech allowed, just you and your curiosity.",
+  title: "Homborsund AI",
+  description:
+    "Community-driven AI meetups, articles and coastal summits in Homborsund",
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,56 @@
-import { Conferance } from "@/components/conferance";
+import Link from "next/link";
 
-export default function Home() {
-  return <Conferance year="2025.2" />;
+export default function Landing() {
+  return (
+    <main className="flex flex-col items-center p-8 space-y-12">
+      <section className="text-center space-y-4 max-w-3xl">
+        <h1 className="text-4xl font-bold">Welcome to Homborsund AI</h1>
+        <p className="text-gray-600">
+          Homborsund AI is a friendly community for anyone curious about the
+          future of artificial intelligence. We meet to share ideas, learn from
+          each other and occasionally host summits by the sea.
+        </p>
+        <p className="text-gray-600">
+          Whether you&apos;re a seasoned researcher or just getting started, we
+          invite you to join us. Explore our articles, take part in local meetups
+          and connect with like-minded enthusiasts.
+        </p>
+      </section>
+
+      <section className="w-full max-w-3xl space-y-4">
+        <h2 className="text-3xl font-bold text-center">Get Involved</h2>
+        <p className="text-center text-gray-600">
+          Learn more about the community or check out our latest posts.
+        </p>
+        <div className="flex flex-col md:flex-row justify-center gap-4">
+          <Link
+            href="/community"
+            className="bg-gray-900 text-white px-6 py-3 rounded-md hover:bg-gray-800"
+          >
+            About the Community
+          </Link>
+          <Link
+            href="/articles"
+            className="bg-indigo-700 text-white px-6 py-3 rounded-md hover:bg-indigo-600"
+          >
+            Read Articles
+          </Link>
+        </div>
+      </section>
+
+      <section className="w-full max-w-3xl space-y-4 text-center">
+        <h2 className="text-3xl font-bold">Next Summit</h2>
+        <p className="text-gray-600">
+          Our next gathering focuses on flashy agents and friendly robots. Join
+          us by the coast for hands-on sessions and discussions.
+        </p>
+        <Link
+          href="/summits"
+          className="inline-block bg-rose-800 text-white px-8 py-3 rounded-md hover:bg-rose-700"
+        >
+          Explore Summits
+        </Link>
+      </section>
+    </main>
+  );
 }

--- a/app/summits/page.tsx
+++ b/app/summits/page.tsx
@@ -1,0 +1,5 @@
+import { Conferance } from "@/components/conferance";
+
+export default function SummitsPage() {
+  return <Conferance year="2025.2" />;
+}


### PR DESCRIPTION
## Summary
- switch root to a simple landing page with links to community, summits and articles
- keep the conference content under /summits
- add placeholder pages for community info and future articles
- update site metadata
- expand landing page text about the community and summits

## Testing
- `npm run build` *(fails: `next: not found`)*