### PR TITLE
Remove registered count and 30 participant limit

### DIFF
--- a/app/summit/2025.1/page.tsx
+++ b/app/summit/2025.1/page.tsx
@@ -230,7 +230,7 @@ export default function Summit2025_1Page() {
               <ul className="list-disc pl-6 space-y-2 marker:text-copperrose">
                 <li><strong>Bring the right spirit</strong> — A blend of curiosity, openness, and willingness to disconnect from technology to connect with ideas and people</li>
                 <li><strong>Contribute to the potluck</strong> — Both literally (bring food/drinks) and figuratively (bring ideas, questions, and enthusiasm)</li>
-                <li><strong>Extend the circle</strong> — Invite someone who would add value to our discussions (but remember space is limited to 30 participants)</li>
+                <li><strong>Extend the circle</strong> — Invite someone who would add value to our discussions (but remember space is limited)</li>
               </ul>
               <p className="italic text-copperrose pt-2">
                 &quot;The best gatherings are those where each person feels personally responsible for its success.&quot;

--- a/app/summit/2025.2/page.tsx
+++ b/app/summit/2025.2/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { SummitHeader, SummitSchedule, SummitSpeakers, SummitVenue, SummitRegistration } from "@/components/shared";
 import { SUMMIT_METADATA } from "@/lib/summit-config";
 
@@ -8,7 +8,6 @@ const YEAR = "2025.2";
 
 export default function Summit2025_2Page() {
   const summitInfo = SUMMIT_METADATA[YEAR];
-  const [registeredCount, setRegisteredCount] = useState(0);
   
   // Inline summit content
   const description = [
@@ -45,23 +44,6 @@ export default function Summit2025_2Page() {
     return () => document.removeEventListener('click', handleAnchorClick);
   }, []);
 
-  useEffect(() => {
-    const fetchRegisteredCount = async () => {
-      try {
-        const response = await fetch('/api/summit/register');
-        if (response.ok) {
-          const data = await response.json();
-          setRegisteredCount(data.count);
-        } else {
-          console.error('Failed to fetch registered count');
-        }
-      } catch (error) {
-        console.error('Error fetching registered count:', error);
-      }
-    };
-
-    fetchRegisteredCount();
-  }, []);
 
   return (
     <main className="flex flex-col min-h-screen bg-gradient-cool text-white">
@@ -76,11 +58,6 @@ export default function Summit2025_2Page() {
       <SummitSpeakers activeYear={YEAR} />
       <SummitVenue activeYear={YEAR} />
       <SummitRegistration activeYear={YEAR} status={summitInfo.status} />
-      <div className="py-8 text-center">
-        <p className="text-xl">
-          So far registered: {registeredCount}
-        </p>
-      </div>
     </main>
   );
 } 

--- a/components/shared/summit-registration.tsx
+++ b/components/shared/summit-registration.tsx
@@ -38,9 +38,9 @@ export function SummitRegistration({ activeYear, status }: SummitRegistrationPro
                 Register Now
               </Link>
               <p className="text-xs text-rosebud-300">
-                {activeYear === "2025.2" 
-                  ? "Fill out our registration form to secure your spot. Limited to 30 participants for an intimate experience."
-                  : "Early bird tickets available until March 1st, 2025. Limited to 30 participants for an intimate experience. Join our WhatsApp community."
+                {activeYear === "2025.2"
+                  ? "Fill out our registration form to secure your spot."
+                  : "Early bird tickets available until March 1st, 2025. Join our WhatsApp community."
                 }
               </p>
             </>


### PR DESCRIPTION
## Summary
- remove registered count section from 2025.2 summit page
- remove references to a 30 participant limit in registration and 2025.1 page

## Testing
- `npm test` *(fails: next build not found because node modules are missing)*

------
https://chatgpt.com/codex/tasks/task_b_683ac7d2cafc833296872d6ada883575