### PR TITLE
Fix invalid URL in admin dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';
+import { headers } from 'next/headers';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,10 +16,17 @@ export default async function AdminDashboard() {
     );
   }
 
-  const res = await fetch(
-    `${process.env.NEXTAUTH_URL ?? ''}/api/summit/registrations`,
-    { cache: 'no-store' }
-  );
+  const incomingHeaders = headers();
+  const protocol = incomingHeaders.get('x-forwarded-proto') ?? 'http';
+  const host = incomingHeaders.get('host');
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.NEXTAUTH_URL ||
+    `${protocol}://${host}`;
+
+  const res = await fetch(`${baseUrl}/api/summit/registrations`, {
+    cache: 'no-store',
+  });
   const { summitCounts } = (await res.json()) as {
     summitCounts: Record<string, number>;
   };


### PR DESCRIPTION
## Summary
- ensure admin dashboard constructs an absolute URL for fetching registration counts

## Testing
- `pnpm test` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68432cfdf3a88332bf7f5370df3518a2