### PR TITLE
Add next-intl translations across pages

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,15 +3,17 @@ import { authOptions } from '@/lib/auth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';
 import { headers } from 'next/headers';
+import { getTranslations } from 'next-intl/server';
 
 export const dynamic = 'force-dynamic';
 
 export default async function AdminDashboard() {
+  const t = await getTranslations('Admin');
   const session = await getServerSession(authOptions);
   if (!session) {
     return (
       <div className="container mx-auto py-10 text-center">
-        <a className="underline" href="/api/auth/signin">Sign in with Google</a>
+        <a className="underline" href="/api/auth/signin">{t('signIn')}</a>
       </div>
     );
   }
@@ -36,11 +38,11 @@ export default async function AdminDashboard() {
       {Object.entries(summitCounts).map(([summit, count]) => (
         <Card key={summit}>
           <CardHeader>
-            <CardTitle>Summit {summit}</CardTitle>
+            <CardTitle>{t('summitLabel', { year: summit })}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            <p>{count} registrations</p>
-            <Link className="underline" href={`/api/admin/registrations?summit=${summit}`}>Download JSON</Link>
+            <p>{t('registrationsCount', { count })}</p>
+            <Link className="underline" href={`/api/admin/registrations?summit=${summit}`}>{t('downloadJson')}</Link>
           </CardContent>
         </Card>
       ))}

--- a/app/admin/registrations/page.tsx
+++ b/app/admin/registrations/page.tsx
@@ -1,9 +1,11 @@
 import AdminRegistrations from '@/components/admin-registrations';
+import { getTranslations } from 'next-intl/server';
 
-export default function RegistrationsPage() {
+export default async function RegistrationsPage() {
+  const t = await getTranslations('Admin');
   return (
     <main className="container mx-auto py-10">
-      <h1 className="text-3xl font-bold mb-6">Registrations</h1>
+      <h1 className="text-3xl font-bold mb-6">{t('registrationsTitle')}</h1>
       <AdminRegistrations />
     </main>
   );

--- a/app/admin/verify/page.tsx
+++ b/app/admin/verify/page.tsx
@@ -1,9 +1,11 @@
 import VerifyTicket from '@/components/verify-ticket';
+import { getTranslations } from 'next-intl/server';
 
-export default function VerifyPage() {
+export default async function VerifyPage() {
+  const t = await getTranslations('Admin');
   return (
     <main className="container mx-auto py-10">
-      <h1 className="text-3xl font-bold mb-6">Verify Ticket</h1>
+      <h1 className="text-3xl font-bold mb-6">{t('verifyTitle')}</h1>
       <VerifyTicket />
     </main>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,27 +1,32 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { Analytics } from "@vercel/analytics/react"
-import AuthProvider from "@/components/auth-provider"
+import { Analytics } from "@vercel/analytics/react";
+import AuthProvider from "@/components/auth-provider";
+import { NextIntlClientProvider } from "next-intl";
+import staticMessages from "../messages/en.json";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Homborsund AI Conference",
-  description: "No tech allowed, just you and your curiosity.",
+  title: staticMessages.Layout.title,
+  description: staticMessages.Layout.description,
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const messages = (await import("../messages/en.json")).default as any;
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AuthProvider>
-          {children}
-        </AuthProvider>
+        <NextIntlClientProvider messages={messages} locale="en">
+          <AuthProvider>
+            {children}
+          </AuthProvider>
+        </NextIntlClientProvider>
         <Analytics />
       </body>
     </html>

--- a/app/summit/2024/page.tsx
+++ b/app/summit/2024/page.tsx
@@ -3,25 +3,22 @@
 import { useEffect } from "react";
 import { SummitHeader, SummitSchedule, SummitSpeakers, SummitVenue, SummitRegistration } from "@/components/shared";
 import { SUMMIT_METADATA } from "@/lib/summit-config";
+import messages from "../../../messages/en.json";
+import { useTranslations } from "next-intl";
 
 const YEAR = "2024";
 
 export default function Summit2024Page() {
   const summitInfo = SUMMIT_METADATA[YEAR];
+  const t = useTranslations('Summits.2024');
   
   // Inline summit content
-  const description = [
-    "Join us for a deep dive into the fundamentals of AI, where we'll explore the core concepts and techniques that power the latest advancements.",
-    "No tech allowed, just you and your curiosity."
-  ];
+  const description = messages.Summits["2024"].description;
 
-  const schedule = [
-    { time: "16:00 - 18:00", event: "Drinks and food, networking" },
-    { time: "18:00 - 19:30", event: "Various introductions" },
-    { time: "19:30 - 21:00", event: "AI: Are we there yet?" },
-    { time: "21:00 - 22:00", event: "And what next?" },
-    { time: "22:00 - Late", event: "Let's talk about it" }
-  ];
+  const schedule = messages.Summits["2024"].schedule.map((item) => {
+    const [time, event] = item.split('|');
+    return { time, event };
+  });
 
   // Add smooth scrolling for anchor links
   useEffect(() => {
@@ -62,16 +59,16 @@ export default function Summit2024Page() {
       <section className="w-full py-12 md:py-24 lg:py-32 bg-ferra bg-opacity-50">
         <div className="container mx-auto px-4 md:px-6">
           <div className="flex flex-col items-center text-center space-y-4">
-            <div className="inline-block rounded-lg bg-rosebud px-3 py-1 text-sm text-tarawera">Archive</div>
-            <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose">Past Summits</h2>
+            <div className="inline-block rounded-lg bg-rosebud px-3 py-1 text-sm text-tarawera">{t('archiveBadge')}</div>
+            <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose">{t('pastHeading')}</h2>
             <p className="max-w-[700px] text-rosebud-200 md:text-xl">
-              Take a look at our previous AI summits and the amazing discussions we had.
+              {t('pastIntro')}
             </p>
             
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
               {/* Photo gallery from past summit */}
               <div className="space-y-4">
-                <h3 className="text-2xl font-semibold text-rosebud-100">Photo Highlights</h3>
+                <h3 className="text-2xl font-semibold text-rosebud-100">{t('photoHighlights')}</h3>
                 <div className="grid grid-cols-2 gap-2">
                   {[1, 2, 3, 4].map((num) => (
                     <div key={num} className="aspect-square bg-ferra-700 border border-ferra-600 rounded-md flex items-center justify-center">
@@ -83,15 +80,15 @@ export default function Summit2024Page() {
               
               {/* Testimonials from past summit */}
               <div className="space-y-4">
-                <h3 className="text-2xl font-semibold text-rosebud-100">Attendee Feedback</h3>
+                <h3 className="text-2xl font-semibold text-rosebud-100">{t('attendeeFeedback')}</h3>
                 <div className="space-y-4">
                   <blockquote className="border-l-4 border-copperrose pl-4 italic text-rosebud-200">
-                    &quot;The discussions were eye-opening. Can&apos;t wait for next year&apos;s summit!&quot;
-                    <footer className="text-sm mt-2 text-rosebud-300">— Previous Attendee</footer>
+                    {t('quote1')}
+                    <footer className="text-sm mt-2 text-rosebud-300">{t('quote1By')}</footer>
                   </blockquote>
                   <blockquote className="border-l-4 border-copperrose pl-4 italic text-rosebud-200">
-                    &quot;A perfect blend of technical insights and practical applications.&quot;
-                    <footer className="text-sm mt-2 text-rosebud-300">— AI Enthusiast</footer>
+                    {t('quote2')}
+                    <footer className="text-sm mt-2 text-rosebud-300">{t('quote2By')}</footer>
                   </blockquote>
                 </div>
               </div>

--- a/app/summit/2025.1/page.tsx
+++ b/app/summit/2025.1/page.tsx
@@ -7,28 +7,22 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { HelpCircle, Lightbulb, Users } from "lucide-react";
 import { SummitHeader, SummitSchedule, SummitSpeakers, SummitVenue, SummitRegistration } from "@/components/shared";
 import { SUMMIT_METADATA } from "@/lib/summit-config";
+import messages from "../../../messages/en.json";
+import { useTranslations } from "next-intl";
 
 const YEAR = "2025.1";
 
 export default function Summit2025_1Page() {
   const summitInfo = SUMMIT_METADATA[YEAR];
   
-  // Inline summit content
-  const description = [
-    "The second annual gathering for AI enthusiasts and professionals to discuss real-world applications and the future of artificial intelligence, focusing on agentic capabilities and multimodal interaction.",
-    "Experience the latest breakthroughs just weeks after the expected release of OpenAI's o4-mini and o3 models, alongside competitors like GPT-4.5 Orion, Claude 3.7 Sonnet, and Grok 3 — exploring the shift towards AI agents that can reason, use tools (like Codex CLI!), understand diverse data types, and perhaps one day, take physical form.",
-    "But it's not all about GenAI! This year we're diving deep into the silicon battles, the rise of agentic frameworks, multimodal understanding, the path towards general-purpose agents, and the ML approaches that power our AI.",
-    "No tech allowed, just you and your curiosity — we'll provide the inspiration in nature's own environment, far from the hum of NVIDIA's H200 server farms."
-  ];
+  const t = useTranslations('Summits.2025.1');
 
-  const schedule = [
-    { time: "16:00 - 18:00", event: "Welcome reception and networking (please bring food and drinks to share - bring something that even a trained chef ML model would approve of!)" },
-    { time: "18:00 - 19:00", event: "Opening keynote: 'The Great GPU Hunger Games' - How NVIDIA went from gaming company to AI overlord, and why Jensen Huang's leather jacket contains more computing power than the entire Internet circa 2005" },
-    { time: "19:00 - 20:00", event: "Panel: 'DeepSeek vs NVIDIA: David's Slingshot Moment' - How DeepSeek's R1 model is challenging NVIDIA's dominance by bypassing traditional GPU constraints" },
-    { time: "20:00 - 21:00", event: "Workshop: 'Traditional ML's Revenge: When Simple Models Beat Giant Transformers' - Interactive demonstrations of when good old decision trees and random forests outperform their ChatGPT cousins" },
-    { time: "21:00 - 22:00", event: "Debate: 'ML vs GenAI: The Battle for AI's Soul' - Has the GenAI hype overshadowed the steady progress in traditional ML? Two teams, one utedo toilet break, unlimited philosophical ammunition" },
-    { time: "22:00 - Late", event: "Campfire discussions under the stars - 'Ghost Stories About Runaway Training Jobs and Other AI Horrors' - Bring blankets, warm drinks, and your most expensive failed experiment stories" }
-  ];
+  const description = messages.Summits["2025.1"].description;
+
+  const schedule = messages.Summits["2025.1"].schedule.map((item) => {
+    const [time, event] = item.split('|');
+    return { time, event };
+  });
 
   // Add smooth scrolling for anchor links
   useEffect(() => {
@@ -65,31 +59,31 @@ export default function Summit2025_1Page() {
       <section className="w-full py-8">
         <div className="container mx-auto px-4 md:px-6">
           <div className="w-full max-w-4xl mx-auto">
-            <h3 className="text-2xl font-semibold mb-6 text-center text-rosebud-200">Jump to a section:</h3>
+            <h3 className="text-2xl font-semibold mb-6 text-center text-rosebud-200">{t('navHeading')}</h3>
             <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#schedule">Schedule</a>
+                <a href="#schedule">{t('navLinks.schedule')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#topics">Hot Topics</a>
+                <a href="#topics">{t('navLinks.topics')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#norwegian">Norwegian ML</a>
+                <a href="#norwegian">{t('navLinks.norwegian')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#attend">How to Attend</a>
+                <a href="#attend">{t('navLinks.attend')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#speakers">Speakers</a>
+                <a href="#speakers">{t('navLinks.speakers')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#venue">Venue</a>
+                <a href="#venue">{t('navLinks.venue')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-copperrose text-copperrose hover:bg-copperrose hover:text-white flex items-center justify-center text-base py-3">
-                <a href="#experience">Experience</a>
+                <a href="#experience">{t('navLinks.experience')}</a>
               </Button>
               <Button asChild variant="outline" size="lg" className="border-rosebud text-rosebud hover:bg-rosebud hover:text-tarawera flex items-center justify-center text-base py-3 col-span-2 md:col-span-1 lg:col-span-1">
-                <a href="#register">Register Now</a>
+                <a href="#register">{t('navLinks.register')}</a>
               </Button>
             </div>
           </div>

--- a/app/summit/2025.2/page.tsx
+++ b/app/summit/2025.2/page.tsx
@@ -3,25 +3,17 @@
 import { useEffect } from "react";
 import { SummitHeader, SummitSchedule, SummitSpeakers, SummitVenue, SummitRegistration } from "@/components/shared";
 import { SUMMIT_METADATA } from "@/lib/summit-config";
+import messages from "../../../messages/en.json";
 
 const YEAR = "2025.2";
 
 export default function Summit2025_2Page() {
   const summitInfo = SUMMIT_METADATA[YEAR];
-  
-  // Inline summit content
-  const description = [
-    "Our third gathering pushes AI into the physical world with robots, drones and more.",
-    "Expect shiny demos and hands-on sessions powered by the latest agentic models.",
-    "Full program will drop after the summer—keep your calendars open!"
-  ];
-
-  const schedule = [
-    { time: "16:00 - 17:00", event: "Arrival, snacks and mingling" },
-    { time: "17:00 - 18:00", event: "Keynote: 'Agents Everywhere'" },
-    { time: "18:00 - 19:30", event: "Demo Jam & Breakouts" },
-    { time: "19:30 - Late", event: "BBQ, bonfire and lightning talks" }
-  ];
+  const description = messages.Summits["2025.2"].description;
+  const schedule = messages.Summits["2025.2"].schedule.map((item) => {
+    const [time, event] = item.split('|');
+    return { time, event };
+  });
 
   // Add smooth scrolling for anchor links
   useEffect(() => {

--- a/app/summit/2025.2/register/page.tsx
+++ b/app/summit/2025.2/register/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import QRCode from 'qrcode';
 import Image from 'next/image';
+import { useTranslations } from "next-intl";
 
 // Declare turnstile global object
 declare global {
@@ -29,6 +30,7 @@ declare global {
 }
 
 export default function RegisterPage() {
+  const t = useTranslations('Ticket');
   const router = useRouter();
   const [formData, setFormData] = useState({
     name: "",
@@ -231,7 +233,7 @@ export default function RegisterPage() {
               </p>
               {qrDataUrl ? (
                 <div className="flex flex-col items-center space-y-2">
-                  <Image src={qrDataUrl} alt="Ticket QR Code" className="bg-white p-2 rounded" width={200} height={200} />
+                  <Image src={qrDataUrl} alt={t('qrCodeAlt')} className="bg-white p-2 rounded" width={200} height={200} />
                   <Link href={registrationSuccessDetails.ticketUrl} target="_blank" rel="noopener noreferrer" className="text-rosebud-300 hover:text-rosebud-100 underline text-sm">
                     {`${window.location.origin}${registrationSuccessDetails.ticketUrl}`}
                   </Link>

--- a/app/ticket/[id]/page.tsx
+++ b/app/ticket/[id]/page.tsx
@@ -1,15 +1,17 @@
 import { getRegistration } from '@/lib/registrations';
 import QRCode from 'qrcode';
 import Image from 'next/image';
+import { getTranslations } from 'next-intl/server';
 
 export default async function TicketPage({ params }: { params: { id: string } }) {
+  const t = await getTranslations('VerifyTicket');
   const decodedId = decodeURIComponent(params.id);
   const reg = await getRegistration(decodedId);
 
   if (!reg) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-gradient-cool text-white">
-        <p>Ticket not found.</p>
+        <p>{t('ticketNotFound')}</p>
       </div>
     );
   }
@@ -24,13 +26,13 @@ export default async function TicketPage({ params }: { params: { id: string } })
 
   return (
     <main className="flex flex-col items-center justify-center min-h-screen gap-4 bg-gradient-cool text-white">
-      <h1 className="text-2xl font-bold">Your Ticket</h1>
+      <h1 className="text-2xl font-bold">{t('yourTicket')}</h1>
       {qrDataUrl ? (
-        <Image src={qrDataUrl} alt="Ticket QR" className="bg-white p-2 rounded" width={200} height={200} />
+        <Image src={qrDataUrl} alt={t('qrAlt')} className="bg-white p-2 rounded" width={200} height={200} />
       ) : (
-        <p>Could not generate QR code.</p>
+        <p>{t('couldNotGenerate')}</p>
       )}
-      <p className="text-rosebud-200 text-sm">Present this code at the entrance.</p>
+      <p className="text-rosebud-200 text-sm">{t('present')}</p>
     </main>
   );
 }

--- a/components/admin-registrations.tsx
+++ b/components/admin-registrations.tsx
@@ -3,15 +3,17 @@ import useSWR from "swr";
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
 export default function AdminRegistrations() {
+  const t = useTranslations('AdminRegistrations');
   const searchParams = useSearchParams();
   const summit = searchParams.get('summit');
   const url = summit ? `/api/admin/registrations?summit=${summit}` : '/api/admin/registrations';
   const { data, mutate } = useSWR(url, fetcher);
-  if (!data) return <p>Loading...</p>;
+  if (!data) return <p>{t('loading')}</p>;
   return (
     <div className="space-y-4">
       {data.registrations.map((reg: any) => (
@@ -22,6 +24,7 @@ export default function AdminRegistrations() {
 }
 
 function RegistrationItem({ reg, onUpdated }: { reg: any; onUpdated: () => void }) {
+  const t = useTranslations('AdminRegistrations');
   const [edit, setEdit] = useState(false);
   const [form, setForm] = useState(reg);
 
@@ -36,7 +39,7 @@ function RegistrationItem({ reg, onUpdated }: { reg: any; onUpdated: () => void 
   };
 
   const deleteRegistration = async () => {
-    if (window.confirm("Are you sure you want to delete this registration?")) {
+    if (window.confirm(t('confirmDelete'))) {
       await fetch(`/api/admin/registrations/${reg.id}`, {
         method: 'DELETE',
       });
@@ -67,14 +70,14 @@ function RegistrationItem({ reg, onUpdated }: { reg: any; onUpdated: () => void 
             className="w-full border p-1 text-black"
             value={form.comment}
             onChange={e => setForm({ ...form, comment: e.target.value })}
-            placeholder="Comment"
+            placeholder={t('commentPlaceholder')}
           />
           <div className="flex space-x-2">
-            <Button onClick={save}>Save</Button>
+            <Button onClick={save}>{t('save')}</Button>
             <Button variant="outline" onClick={() => {
               setEdit(false);
               setForm(reg); // Reset form to original data
-            }}>Cancel</Button>
+            }}>{t('cancel')}</Button>
           </div>
         </div>
       ) : (
@@ -83,16 +86,16 @@ function RegistrationItem({ reg, onUpdated }: { reg: any; onUpdated: () => void 
             <p className="font-semibold">{reg.name}</p>
             <p className="text-sm text-gray-400">{reg.email}</p>
             {reg.phone && <p className="text-sm text-gray-400">{reg.phone}</p>}
-            {reg.comment && <p className="text-sm text-gray-500 mt-1">Comment: {reg.comment}</p>}
-            <p className="text-sm text-gray-400">ID: {reg.id}</p>
-            {reg.timestamp && <p className="text-sm text-gray-400">Timestamp: {new Date(reg.timestamp).toUTCString()}</p>}
+            {reg.comment && <p className="text-sm text-gray-500 mt-1">{t('commentDisplay')} {reg.comment}</p>}
+            <p className="text-sm text-gray-400">{t('idLabel')} {reg.id}</p>
+            {reg.timestamp && <p className="text-sm text-gray-400">{t('timestampLabel')} {new Date(reg.timestamp).toUTCString()}</p>}
           </div>
           <div className="flex space-x-2">
             <Button variant="secondary" onClick={() => setEdit(true)}>
-              Edit
+              {t('edit')}
             </Button>
             <Button variant="destructive" onClick={deleteRegistration}>
-              Delete
+              {t('delete')}
             </Button>
           </div>
         </div>

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card"; // Assuming these are now available
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel"; // Assuming these are now available
 import { Button } from "@/components/ui/button"; // Assuming this is now available
+import { useTranslations } from "next-intl";
 import { ArrowRight } from "lucide-react"; // Assuming lucide-react is available
 
 // Placeholder icons (actual icons would be imported from lucide-react or similar)
@@ -19,19 +20,18 @@ import { ArrowRight } from "lucide-react"; // Assuming lucide-react is available
 
 
 export default function LandingPage() {
+  const t = useTranslations("Landing");
   return (
     <div className="flex flex-col min-h-screen bg-gradient-cool text-white">
       {/* Hero Section */}
       <section className="flex flex-col items-center justify-center text-center py-20 md:py-32 lg:py-40 px-4 md:px-6 bg-opacity-50">
-        <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 animate-fade-in-down">
-          Homborsund AI: <span className="text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose">Ignite Your AI Journey</span>
-        </h1>
+        <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight mb-6 animate-fade-in-down" dangerouslySetInnerHTML={{__html: t('heroTitle')}} />
         <p className="text-lg md:text-xl lg:text-2xl text-rosebud-200 max-w-3xl mb-10 animate-fade-in-up" style={{ animationDelay: '0.2s' }}>
-          Step into the epicenter of AI innovation. Connect with brilliant minds, explore groundbreaking ideas, and collaboratively shape the future. This is where AI&apos;s brightest sparks converge. Don&apos;t just witness the future – create it with us.
+          {t('heroSubtitle')}
         </p>
         <Link href="/summit">
           <Button size="lg" className="bg-copperrose hover:bg-copperrose-600 text-white font-semibold py-3 px-8 rounded-lg text-lg shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105 animate-bounce-slow" style={{ animationDelay: '0.4s' }}>
-            Explore the Summit <ArrowRight className="ml-2 h-5 w-5" />
+            {t('exploreButton')} <ArrowRight className="ml-2 h-5 w-5" />
           </Button>
         </Link>
       </section>
@@ -150,22 +150,20 @@ export default function LandingPage() {
       {/* Final Call to Action */}
       <section className="py-20 md:py-32 text-center bg-tarawera bg-opacity-80">
         <div className="container mx-auto px-4 md:px-6">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 tracking-tight">
-            Ready to Be Part of the <span className="text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose">Next Wave</span>?
-          </h2>
+          <h2 className="text-4xl md:text-5xl font-bold mb-6 tracking-tight" dangerouslySetInnerHTML={{__html: t('callHeading')}} />
           <p className="text-lg md:text-xl text-rosebud-200 max-w-2xl mx-auto mb-10">
-            The future of AI is not just coming; it's being built right here, right now. Join Homborsund AI and leave your mark.
+            {t('callText')}
           </p>
           <Link href="/summit">
             <Button size="lg" className="bg-gradient-to-r from-copperrose to-ferra hover:from-copperrose-600 hover:to-ferra-600 text-white font-bold py-4 px-10 rounded-xl text-xl shadow-2xl hover:shadow-rosebud/50 transition-all duration-300 transform hover:scale-105">
-              Dive Into the Summit Details
+              {t('diveButton')}
             </Button>
           </Link>
         </div>
       </section>
 
       <footer className="py-8 text-center text-rosebud-300 border-t border-ferra-600">
-        <p>&copy; {new Date().getFullYear()} Homborsund AI. Org. nr: 935616913. The Future is Collaborative.</p>
+        <p dangerouslySetInnerHTML={{__html: t('footer', {year: new Date().getFullYear()})}} />
       </footer>
     </div>
   );

--- a/components/shared/summit-header.tsx
+++ b/components/shared/summit-header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { DEFAULT_YEAR, SUMMIT_METADATA, type SummitMetadata } from "@/lib/summit-config";
 
 type SummitHeaderProps = {
@@ -13,6 +14,7 @@ type SummitHeaderProps = {
 }
 
 export function SummitHeader({ activeYear, title, date, theme, description }: SummitHeaderProps) {
+  const t = useTranslations('Shared');
   return (
     <>
       {/* Back to Home Link */}
@@ -23,7 +25,7 @@ export function SummitHeader({ activeYear, title, date, theme, description }: Su
             className="inline-flex items-center gap-2 text-rosebud-200 hover:text-rosebud transition-colors duration-200 group"
           >
             <ArrowLeft className="w-4 h-4 transition-transform duration-200 group-hover:-translate-x-1" />
-            <span className="text-sm font-medium">Back to Home</span>
+            <span className="text-sm font-medium">{t('backToHome')}</span>
           </Link>
         </div>
       </div>
@@ -41,10 +43,10 @@ export function SummitHeader({ activeYear, title, date, theme, description }: Su
                     : "bg-ferra-700 hover:bg-ferra-600 text-rosebud-200 border border-ferra-600"
                 }`}
               >
-                Summit {summitYear}
+                {t('summitLabel', { year: summitYear })}
                 {SUMMIT_METADATA[summitYear].status === "Upcoming" && summitYear === DEFAULT_YEAR && (
                   <span className="ml-2 text-xs bg-rosebud text-tarawera px-2 py-0.5 rounded-full">
-                    Next
+                    {t('nextBadge')}
                   </span>
                 )}
               </Link>

--- a/components/shared/summit-registration.tsx
+++ b/components/shared/summit-registration.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { DEFAULT_YEAR } from "@/lib/summit-config";
+import { useTranslations } from "next-intl";
 
 type SummitRegistrationProps = {
   activeYear: string;
@@ -7,21 +8,22 @@ type SummitRegistrationProps = {
 }
 
 export function SummitRegistration({ activeYear, status }: SummitRegistrationProps) {
+  const t = useTranslations('Registration');
   return (
     <section id="register" className="w-full py-12 md:py-24 lg:py-32 border-t border-ferra-600 scroll-mt-16 bg-tarawera bg-opacity-30">
       <div className="container mx-auto grid items-center justify-center gap-4 px-4 text-center md:px-6">
         <div className="space-y-3">
           <h2 className="text-3xl font-bold tracking-tighter md:text-4xl/tight">
             {activeYear === DEFAULT_YEAR ? (
-              <span className="bg-gradient-to-r from-rosebud to-copperrose bg-clip-text text-transparent">Join us at the Homborsund AI Summit {activeYear}</span>
+              <span className="bg-gradient-to-r from-rosebud to-copperrose bg-clip-text text-transparent">{t('joinTitle', { year: activeYear })}</span>
             ) : (
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose">Join us at the Homborsund AI Summit {activeYear}</span>
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose">{t('joinTitle', { year: activeYear })}</span>
             )}
           </h2>
           <p className="mx-auto max-w-[600px] text-rosebud-200 md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed">
-            {status === "Upcoming" 
-              ? "Register now to secure your spot and be a part of this exciting event where cutting-edge AI concepts meet authentic human connection."
-              : "This event has concluded. Check out our upcoming summit!"}
+            {status === "Upcoming"
+              ? t('upcomingDesc')
+              : t('completedDesc')}
           </p>
         </div>
         <div className="mx-auto w-full max-w-sm space-y-2">
@@ -35,12 +37,12 @@ export function SummitRegistration({ activeYear, status }: SummitRegistrationPro
                 }`}
                 href={activeYear === "2025.2" ? `/summit/${activeYear}/register` : "https://chat.whatsapp.com/FWv18Iz2r59CuQb98LBuUQ"}
               >
-                Register Now
+                {t('registerButton')}
               </Link>
               <p className="text-xs text-rosebud-300">
                 {activeYear === "2025.2"
-                  ? "Fill out our registration form to secure your spot."
-                  : "Early bird tickets available until March 1st, 2025. Join our WhatsApp community."
+                  ? t('registerNoteForm')
+                  : t('registerNoteWhatsapp')
                 }
               </p>
             </>
@@ -49,7 +51,7 @@ export function SummitRegistration({ activeYear, status }: SummitRegistrationPro
               href={`/summit/${DEFAULT_YEAR}`}
               className="inline-flex h-10 items-center justify-center rounded-md bg-gradient-to-r from-copperrose to-ferra hover:from-copperrose-600 hover:to-ferra-600 px-8 text-sm font-medium text-white shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rosebud disabled:pointer-events-none disabled:opacity-50 shadow-lg hover:shadow-rosebud/50"
             >
-              View Upcoming Summit
+              {t('viewUpcomingButton')}
             </Link>
           )}
         </div>

--- a/components/shared/summit-schedule.tsx
+++ b/components/shared/summit-schedule.tsx
@@ -1,5 +1,6 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { useTranslations } from "next-intl";
 
 type ScheduleItem = {
   time: string;
@@ -11,21 +12,22 @@ type SummitScheduleProps = {
 }
 
 export function SummitSchedule({ schedule }: SummitScheduleProps) {
+  const t = useTranslations('Schedule');
   return (
     <section id="schedule" className="w-full scroll-mt-16 bg-ferra bg-opacity-50">
       <div className="container mx-auto px-4 md:px-6 py-12 md:py-16">
         <div className="flex flex-col items-center text-center space-y-4 mb-10 md:mb-12">
-          <div className="bg-rosebud text-tarawera font-semibold px-4 py-1 rounded-full text-sm">Schedule</div>
-          <h2 className="text-4xl md:text-5xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose mb-3">Summit Schedule</h2>
+          <div className="bg-rosebud text-tarawera font-semibold px-4 py-1 rounded-full text-sm">{t('badge')}</div>
+          <h2 className="text-4xl md:text-5xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose mb-3">{t('heading')}</h2>
           <p className="max-w-[700px] text-rosebud-200 md:text-lg">
-            Explore the lineup of thought-provoking talks and interactive sessions.
+            {t('intro')}
           </p>
         </div>
         <div className="mx-auto max-w-3xl w-full">
           <Card className="bg-ferra border-ferra-600 shadow-lg">
             <CardHeader>
               <CardTitle className="text-3xl font-semibold text-center text-rosebud-100">
-                Day 1
+                {t('dayOne')}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6 px-6 py-8">

--- a/components/shared/summit-speakers.tsx
+++ b/components/shared/summit-speakers.tsx
@@ -1,19 +1,21 @@
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { useTranslations } from "next-intl";
 
 type SummitSpeakersProps = {
   activeYear: string;
 }
 
 export function SummitSpeakers({ activeYear }: SummitSpeakersProps) {
+  const t = useTranslations('Speakers');
   return (
     <section id="speakers" className="w-full py-12 md:py-16 scroll-mt-16 bg-tarawera bg-opacity-50">
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex flex-col items-center text-center space-y-4 mb-10 md:mb-12">
-          <div className="bg-rosebud text-tarawera font-semibold px-4 py-1 rounded-full text-sm">Speakers</div>
-          <h2 className="text-4xl md:text-5xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose mb-3">Meet the Speakers</h2>
+          <div className="bg-rosebud text-tarawera font-semibold px-4 py-1 rounded-full text-sm">{t('badge')}</div>
+          <h2 className="text-4xl md:text-5xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose mb-3">{t('heading')}</h2>
           <p className="max-w-[700px] text-rosebud-200 md:text-lg">
-            Learn from industry experts and thought leaders in the field of AI.
+            {t('intro')}
           </p>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">

--- a/components/shared/summit-venue.tsx
+++ b/components/shared/summit-venue.tsx
@@ -1,15 +1,17 @@
 import { DEFAULT_YEAR } from "@/lib/summit-config";
+import { useTranslations } from "next-intl";
 
 type SummitVenueProps = {
   activeYear: string;
 }
 
 export function SummitVenue({ activeYear }: SummitVenueProps) {
+  const t = useTranslations('Venue');
   return (
     <section id="venue" className="w-full py-12 md:py-24 lg:py-32 scroll-mt-16">
       <div className="container mx-auto px-4 md:px-6">
         <div className="flex flex-col items-center text-center space-y-4">
-          <div className="inline-block rounded-lg bg-rosebud px-3 py-1 text-sm text-tarawera">Venue</div>
+          <div className="inline-block rounded-lg bg-rosebud px-3 py-1 text-sm text-tarawera">{t('badge')}</div>
           <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
             {activeYear === DEFAULT_YEAR ? (
               <span className="bg-gradient-to-r from-tarawera to-copperrose bg-clip-text text-transparent">Homborsund Community Center</span>
@@ -18,36 +20,35 @@ export function SummitVenue({ activeYear }: SummitVenueProps) {
             )}
           </h2>
           <p className="max-w-[700px] text-rosebud-200 md:text-xl">
-            The summit will be held at the Vågsholt skole, a historic building located in the heart
-            of Krømpe.
+            {t('introLine1')}
           </p>
         </div>
         <div className="mx-auto grid max-w-5xl items-center gap-6 py-12 lg:grid-cols-2 lg:gap-12">
           <div className="space-y-4">
-            <h3 className="text-2xl font-bold text-rosebud-100">Location Details</h3>
+            <h3 className="text-2xl font-bold text-rosebud-100">{t('locationHeading')}</h3>
             <div className="space-y-2">
               <p className="text-rosebud-300">
-                <span className="font-semibold text-rosebud-100">Address:</span> Vågsholt skole, Krømpe, Norway
+                <span className="font-semibold text-rosebud-100">{t('addressLabel')}</span> {t('address')}
               </p>
               <p className="text-rosebud-300">
-                <span className="font-semibold text-rosebud-100">Parking:</span> Free parking available on-site
+                <span className="font-semibold text-rosebud-100">{t('parkingLabel')}</span> {t('parkingInfo')}
               </p>
               <p className="text-rosebud-300">
-                <span className="font-semibold text-rosebud-100">Accessibility:</span> Wheelchair accessible venue
+                <span className="font-semibold text-rosebud-100">{t('accessibilityLabel')}</span> {t('accessibilityInfo')}
               </p>
             </div>
           </div>
           <div className="space-y-4">
-            <h3 className="text-2xl font-bold text-rosebud-100">Getting There</h3>
+            <h3 className="text-2xl font-bold text-rosebud-100">{t('gettingThereHeading')}</h3>
             <div className="space-y-2">
               <p className="text-rosebud-300">
-                The venue is easily accessible by car and public transport. Detailed directions will be provided upon registration.
+                {t('gettingThereInfo')}
               </p>
               <p className="text-rosebud-300">
-                <span className="font-semibold text-rosebud-100">By Car:</span> 45 minutes from Kristiansand
+                <span className="font-semibold text-rosebud-100">{t('byCarLabel')}</span> {t('byCarInfo')}
               </p>
               <p className="text-rosebud-300">
-                <span className="font-semibold text-rosebud-100">By Public Transport:</span> Bus connections available from major cities
+                <span className="font-semibold text-rosebud-100">{t('byPublicTransportLabel')}</span> {t('byPublicTransportInfo')}
               </p>
             </div>
           </div>

--- a/components/verify-ticket.tsx
+++ b/components/verify-ticket.tsx
@@ -2,10 +2,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Html5QrcodeScanner, Html5QrcodeSupportedFormats } from 'html5-qrcode';
+import { useTranslations } from 'next-intl';
 
 const QR_SCANNER_ELEMENT_ID = "qr-code-full-region";
 
 export default function VerifyTicket() {
+  const t = useTranslations('VerifyTicket');
   const [code, setCode] = useState('');
   const [result, setResult] = useState<any>(null);
   const [error, setError] = useState('');
@@ -24,7 +26,7 @@ export default function VerifyTicket() {
       const data = await res.json();
       setResult(data);
     } else {
-      setError('Ticket not found');
+      setError(t('ticketNotFound'));
     }
     setLoading(false);
   }, [code]);
@@ -50,7 +52,7 @@ export default function VerifyTicket() {
           codeToVerify = unescapedText;
         } catch (e) {
           console.error("Failed to decode URI component, using raw value:", e);
-          setError("Failed to decode QR code, attempting to use raw value.");
+          setError(t('decodeError'));
           // codeToVerify remains decodedText
         }
         setCode(codeToVerify);
@@ -78,7 +80,7 @@ export default function VerifyTicket() {
   return (
     <div className="space-y-4">
       <Button onClick={() => setShowScanner(!showScanner)} variant="outline">
-        {showScanner ? 'Close Scanner' : 'Scan QR Code'}
+        {showScanner ? t('closeScanner') : t('scanQr')}
       </Button>
 
       {showScanner && <div id={QR_SCANNER_ELEMENT_ID} className="w-full md:w-1/2 mx-auto"></div>}
@@ -89,11 +91,11 @@ export default function VerifyTicket() {
             type="text"
             value={code}
             onChange={(e) => setCode(e.target.value)}
-            placeholder="Scan or enter ticket code"
+            placeholder={t('placeholder')}
             className="w-full p-2 border rounded text-black"
           />
           <Button onClick={() => checkTicket()} disabled={!code || loading}>
-            {loading ? 'Checking...' : 'Verify Manually'}
+            {loading ? t('checking') : t('verify')}
           </Button>
         </>
       )}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,158 @@
+{
+  "Layout": {
+    "title": "Homborsund AI Conference",
+    "description": "No tech allowed, just you and your curiosity."
+  },
+  "Landing": {
+    "heroTitle": "Homborsund AI: <span class=\"text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose\">Ignite Your AI Journey</span>",
+    "heroSubtitle": "Step into the epicenter of AI innovation. Connect with brilliant minds, explore groundbreaking ideas, and collaboratively shape the future. This is where AI's brightest sparks converge. Don't just witness the future – create it with us.",
+    "exploreButton": "Explore the Summit",
+    "callHeading": "Ready to Be Part of the <span class=\"text-transparent bg-clip-text bg-gradient-to-r from-rosebud to-copperrose\">Next Wave</span>?",
+    "callText": "The future of AI is not just coming; it's being built right here, right now. Join Homborsund AI and leave your mark.",
+    "diveButton": "Dive Into the Summit Details",
+    "footer": "&copy; {year} Homborsund AI. Org. nr: 935616913. The Future is Collaborative."
+  },
+  "Shared": {
+    "backToHome": "Back to Home",
+    "summitLabel": "Summit {year}",
+    "nextBadge": "Next"
+  },
+  "Schedule": {
+    "badge": "Schedule",
+    "heading": "Summit Schedule",
+    "intro": "Explore the lineup of thought-provoking talks and interactive sessions.",
+    "dayOne": "Day 1"
+  },
+  "Speakers": {
+    "badge": "Speakers",
+    "heading": "Meet the Speakers",
+    "intro": "Learn from industry experts and thought leaders in the field of AI."
+  },
+  "Venue": {
+    "badge": "Venue",
+    "introLine1": "The summit will be held at the Vågsholt skole, a historic building located in the heart of Krømpe.",
+    "locationHeading": "Location Details",
+    "addressLabel": "Address:",
+    "address": "Vågsholt skole, Krømpe, Norway",
+    "parkingLabel": "Parking:",
+    "parkingInfo": "Free parking available on-site",
+    "accessibilityLabel": "Accessibility:",
+    "accessibilityInfo": "Wheelchair accessible venue",
+    "gettingThereHeading": "Getting There",
+    "gettingThereInfo": "The venue is easily accessible by car and public transport. Detailed directions will be provided upon registration.",
+    "byCarLabel": "By Car:",
+    "byCarInfo": "45 minutes from Kristiansand",
+    "byPublicTransportLabel": "By Public Transport:",
+    "byPublicTransportInfo": "Bus connections available from major cities"
+  },
+  "Registration": {
+    "joinTitle": "Join us at the Homborsund AI Summit {year}",
+    "upcomingDesc": "Register now to secure your spot and be a part of this exciting event where cutting-edge AI concepts meet authentic human connection.",
+    "completedDesc": "This event has concluded. Check out our upcoming summit!",
+    "registerButton": "Register Now",
+    "registerNoteForm": "Fill out our registration form to secure your spot.",
+    "registerNoteWhatsapp": "Early bird tickets available until March 1st, 2025. Join our WhatsApp community.",
+    "viewUpcomingButton": "View Upcoming Summit"
+  },
+  "Admin": {
+    "signIn": "Sign in with Google",
+    "registrationsTitle": "Registrations",
+    "verifyTitle": "Verify Ticket",
+    "downloadJson": "Download JSON",
+    "registrationsCount": "{count} registrations"
+  },
+  "VerifyTicket": {
+    "closeScanner": "Close Scanner",
+    "scanQr": "Scan QR Code",
+    "placeholder": "Scan or enter ticket code",
+    "verify": "Verify Manually",
+    "checking": "Checking...",
+    "ticketNotFound": "Ticket not found",
+    "decodeError": "Failed to decode QR code, attempting to use raw value.",
+    "present": "Present this code at the entrance.",
+    "couldNotGenerate": "Could not generate QR code.",
+    "yourTicket": "Your Ticket"
+  },
+  "AdminRegistrations": {
+    "loading": "Loading...",
+    "commentPlaceholder": "Comment",
+    "save": "Save",
+    "cancel": "Cancel",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirmDelete": "Are you sure you want to delete this registration?",
+    "idLabel": "ID:",
+    "timestampLabel": "Timestamp:",
+    "commentDisplay": "Comment:"
+  },
+  "Summits": {
+    "2024": {
+      "description": [
+        "Join us for a deep dive into the fundamentals of AI, where we'll explore the core concepts and techniques that power the latest advancements.",
+        "No tech allowed, just you and your curiosity."
+      ],
+      "schedule": [
+        "16:00 - 18:00|Drinks and food, networking",
+        "18:00 - 19:30|Various introductions",
+        "19:30 - 21:00|AI: Are we there yet?",
+        "21:00 - 22:00|And what next?",
+        "22:00 - Late|Let's talk about it"
+      ],
+      "archiveBadge": "Archive",
+      "pastHeading": "Past Summits",
+      "pastIntro": "Take a look at our previous AI summits and the amazing discussions we had.",
+      "photoHighlights": "Photo Highlights",
+      "attendeeFeedback": "Attendee Feedback",
+      "quote1": "\"The discussions were eye-opening. Can't wait for next year's summit!\"",
+      "quote1By": "— Previous Attendee",
+      "quote2": "\"A perfect blend of technical insights and practical applications.\"",
+      "quote2By": "— AI Enthusiast"
+    },
+    "2025.2": {
+      "description": [
+        "Our third gathering pushes AI into the physical world with robots, drones and more.",
+        "Expect shiny demos and hands-on sessions powered by the latest agentic models.",
+        "Full program will drop after the summer—keep your calendars open!"
+      ],
+      "schedule": [
+        "16:00 - 17:00|Arrival, snacks and mingling",
+        "17:00 - 18:00|Keynote: 'Agents Everywhere'",
+        "18:00 - 19:30|Demo Jam & Breakouts",
+        "19:30 - Late|BBQ, bonfire and lightning talks"
+      ]
+    },
+    "2025.1": {
+      "description": [
+        "The second annual gathering for AI enthusiasts and professionals to discuss real-world applications and the future of artificial intelligence, focusing on agentic capabilities and multimodal interaction.",
+        "Experience the latest breakthroughs just weeks after the expected release of OpenAI's o4-mini and o3 models, alongside competitors like GPT-4.5 Orion, Claude 3.7 Sonnet, and Grok 3 — exploring the shift towards AI agents that can reason, use tools (like Codex CLI!), understand diverse data types, and perhaps one day, take physical form.",
+        "But it's not all about GenAI! This year we're diving deep into the silicon battles, the rise of agentic frameworks, multimodal understanding, the path towards general-purpose agents, and the ML approaches that power our AI.",
+        "No tech allowed, just you and your curiosity — we'll provide the inspiration in nature's own environment, far from the hum of NVIDIA's H200 server farms."
+      ],
+      "schedule": [
+        "16:00 - 18:00|Welcome reception and networking (please bring food and drinks to share - bring something that even a trained chef ML model would approve of!)",
+        "18:00 - 19:00|Opening keynote: 'The Great GPU Hunger Games' - How NVIDIA went from gaming company to AI overlord, and why Jensen Huang's leather jacket contains more computing power than the entire Internet circa 2005",
+        "19:00 - 20:00|Panel: 'DeepSeek vs NVIDIA: David's Slingshot Moment' - How DeepSeek's R1 model is challenging NVIDIA's dominance by bypassing traditional GPU constraints",
+        "20:00 - 21:00|Workshop: 'Traditional ML's Revenge: When Simple Models Beat Giant Transformers' - Interactive demonstrations of when good old decision trees and random forests outperform their ChatGPT cousins",
+        "21:00 - 22:00|Debate: 'ML vs GenAI: The Battle for AI's Soul' - Has the GenAI hype overshadowed the steady progress in traditional ML? Two teams, one utedo toilet break, unlimited philosophical ammunition",
+        "22:00 - Late|Campfire discussions under the stars - 'Ghost Stories About Runaway Training Jobs and Other AI Horrors' - Bring blankets, warm drinks, and your most expensive failed experiment stories"
+      ],
+      "navHeading": "Jump to a section:",
+      "navLinks": {
+        "schedule": "Schedule",
+        "topics": "Hot Topics",
+        "norwegian": "Norwegian ML",
+        "attend": "How to Attend",
+        "speakers": "Speakers",
+        "venue": "Venue",
+        "experience": "Experience",
+        "register": "Register Now"
+      }
+    }
+  },
+  "Ticket": {
+    "notFound": "Ticket not found.",
+    "present": "Present this code at the entrance.",
+    "qrAlt": "Ticket QR",
+    "qrCodeAlt": "Ticket QR Code"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18",
     "resend": "^4.5.1",
     "swr": "^2.3.3",
+    "next-intl": "^3.3.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       next-auth:
         specifier: ^4.24.6
         version: 4.24.11(next@14.2.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-intl:
+        specifier: ^3.3.0
+        version: 3.26.5(next@14.2.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -343,6 +346,24 @@ packages:
 
   '@firebase/util@1.10.0':
     resolution: {integrity: sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==}
+
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
+
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
   '@google-cloud/firestore@7.11.1':
     resolution: {integrity: sha512-ZxOdH8Wr01hBDvKCQfMWqwUcfNcN3JY19k1LtS1fTFhEyorYPLsbWN+VxIRL46pOYGHTPkU3Or5HbT/SLQM5nA==}
@@ -2027,6 +2048,9 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -2596,6 +2620,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next-auth@4.24.11:
     resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
     peerDependencies:
@@ -2609,6 +2637,12 @@ packages:
         optional: true
       nodemailer:
         optional: true
+
+  next-intl@3.26.5:
+    resolution: {integrity: sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==}
+    peerDependencies:
+      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   next@14.2.3:
     resolution: {integrity: sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==}
@@ -3397,6 +3431,11 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-intl@3.26.5:
+    resolution: {integrity: sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+
   use-sync-external-store@1.5.0:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
     peerDependencies:
@@ -3843,6 +3882,36 @@ snapshots:
       tslib: 2.8.1
 
   '@firebase/util@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.5.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.5.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
     dependencies:
       tslib: 2.8.1
 
@@ -5270,7 +5339,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5300,7 +5369,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5315,7 +5384,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5885,6 +5954,13 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  intl-messageformat@10.7.16:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      tslib: 2.8.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -6672,6 +6748,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   next-auth@4.24.11(next@14.2.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.27.1
@@ -6686,6 +6764,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
+
+  next-intl@3.26.5(next@14.2.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.5.10
+      negotiator: 1.0.0
+      next: 14.2.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      use-intl: 3.26.5(react@18.3.1)
 
   next@14.2.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -7585,6 +7671,12 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-intl@3.26.5(react@18.3.1):
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      intl-messageformat: 10.7.16
+      react: 18.3.1
 
   use-sync-external-store@1.5.0(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add translation strings for admin, ticket and summit pages
- load summit texts from `messages/en.json`
- localize admin pages and verification components
- cast message import to satisfy TypeScript

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Firebase credentials missing)*

------
https://chatgpt.com/codex/tasks/task_b_6843e801d5d0833287d071496eb05d1e